### PR TITLE
Fix failing test: test_basic_routes

### DIFF
--- a/pyramid_cli/routes.py
+++ b/pyramid_cli/routes.py
@@ -1,5 +1,5 @@
 import click
-from pyramid.config import Configurator
+from pyramid.config import Configurator, not_
 from pyramid.interfaces import IRouteRequest
 from pyramid.interfaces import IViewClassifier
 from pyramid.interfaces import IView
@@ -46,9 +46,20 @@ def _get_request_methods(route_request_methods, view_request_methods):
     if has_methods and not request_methods:
         request_methods = '<route mismatch>'
     elif request_methods:
-        request_methods = ','.join(request_methods)
+        request_methods = _get_request_methods_string(request_methods)
 
     return request_methods
+
+
+def _get_request_methods_string(request_methods):
+    lst = []
+
+    for request_method in request_methods:
+        if isinstance(request_method, not_):
+            request_method = '!' + request_method.value
+        lst.append(request_method)
+
+    return ','.join(lst)
 
 
 def _get_static_view(view_callable):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -32,6 +32,8 @@ multiview                  /multiview                  dummy_starter.standard_vi
 multiview                  /multiview                  dummy_starter.standard_views.hello_world                POST
 class_based_view           /classes                    dummy_starter.standard_views.ClassBasedView.awesome     POST
 factory                    /factory                    dummy_starter.standard_views.route_and_view_attached    *
+not_post                   /not_post                   dummy_starter.standard_views.route_and_view_attached    !POST
+not_post_only_get          /not_post_only_get          dummy_starter.standard_views.route_and_view_attached    <route mismatch>
 """  # noqa
     assert result.exit_code == 0
     final_lines = result.output.split('\n')


### PR DESCRIPTION
It was getting messed up by a `pyramid.config.not_`.

```
$ tox
...
  py27: commands succeeded
  py34: commands succeeded
  pypy: commands succeeded
  flake8: commands succeeded
  cov: commands succeeded
  congratulations :)
```
